### PR TITLE
A few patches and true spline determination

### DIFF
--- a/derivative_function_opt.m
+++ b/derivative_function_opt.m
@@ -1,10 +1,12 @@
 function [value,grad_matrix] = derivative_function_opt(C,N,R,ni,mask)
 %     sp1 = spmak(1:3:19,[1 1 1]);
 %     Nf = fnval(sp1,1:19);
-%     sp1 = spmak(1:2:15,[1 1 1]);
-%     Nf = fnval(sp1,1:15);
-    sp1 = spmak(1:6:37,[1 1 1]);
-    Nf = fnval(sp1,1:37);
+    sp1 = spmak(1:1:7,[1 1 1]);
+    Nf = fnval(sp1,1:7);
+%     sp1 = spmak(1:1:5,[1 1 1]);
+%     Nf = fnval(sp1,1:5);
+%     sp1 = spmak(1:6:37,[1 1 1]);
+%     Nf = fnval(sp1,1:37);
     Nf = Nf./10;
     if ~isempty(size(C,5)) || size(C,5) < 1
         C = squeeze(C);

--- a/maximizing_function.m
+++ b/maximizing_function.m
@@ -8,9 +8,12 @@ function [x,histout,costdata,xc_theta1] = maximizing_function(Nmat, Rmat, mask_i
 % val = fnval(sp1,1:19);
 % val = val./sum(val);
 
-sp1 = spmak(1:2:15,[1 1 1]);
-val = fnval(sp1,1:15);
-val = val./sum(val);
+% sp1 = spmak(1:2:15,[1 1 1]);
+% val = fnval(sp1,1:15);
+sp1 = spmak(1:1:7,[1 1 1]);
+val = fnval(sp1,1:7);
+val = val./(sum(val));
+
 
 % compensating for convolution error
 normalizing_image = convnsep({val,val,val,val},ones(size(Rmat)),'same');
@@ -28,6 +31,7 @@ c00 = Rmat./Nmat;
 c00(~mask) = 0;
 c0 = zeros(size(c00));
 c0(1:2:end,1:2:end,1:2:end,1:2:end) = c00(1:2:end,1:2:end,1:2:end,1:2:end);
+c0 = c00;
 c01 = convnsep({val,val,val,val},c0,'same');
 %c01 = (c01./normalizing_image).*(max(normalizing_image(:)));% smoothed average lesion map (initialization)
 c01 = normalise((c01./normalizing_image));
@@ -42,8 +46,8 @@ lc01_norm = normalise(lc01_norm);
 
 tmp = 2*lc01 - 1;
 % tmp = normalise(convnsep({val1,val1,val1,val1},c00,'same')./convnsep({val1,val1,val1,val1},ones(size(Rmat)),'same'));
-tmp(tmp<-0.99) = -0.99;
-tmp(tmp>0.99) = 0.99;
+tmp(tmp<-0.9999) = -0.9999;
+tmp(tmp>0.9999) = 0.9999;
 lambda = atanh(tmp);
 % lambda = convnsep({val,val,val,val},lambda,'same')./convnsep({val,val,val,val},ones(size(Rmat)),'same');
 

--- a/optimizing_to_estimate_coefficients.m
+++ b/optimizing_to_estimate_coefficients.m
@@ -8,18 +8,19 @@ val = val./sum(val);
 
 load('MNI152_T1_2mm_brain_mask.mat');
 load('NR_details.mat');
-
-% compensating for convolution error
-normalizing_image = convnsep({val,val,val,val},ones(size(Rmat)),'same');
-
 % getting the brain mask, R and N matrices ready
 mask = mask_image > 0;
 mask = repmat(mask,[1,1,1,27]);
 Rmat(~mask) = 0;
 Nmat(~mask) = 0;
 
+% compensating for convolution error
+normalizing_image = convnsep({val,val,val,val},ones(size(Rmat)),'same');
+
+
+
 c00 = 0.5+zeros(size(Nmat));%Rmat./Nmat;
-c00(~mask) = 0;
+% c00(~mask) = 0;
 c0 = zeros(size(c00));
 c0(1:2:end,1:2:end,1:2:end,1:2:end) = c00(1:2:end,1:2:end,1:2:end,1:2:end);
 c01 = convnsep({val,val,val,val},c0,'same');
@@ -42,7 +43,6 @@ lambda = atanh(tmp);
 % lambda = convnsep({val,val,val,val},lambda,'same')./convnsep({val,val,val,val},ones(size(Rmat)),'same');
 
 func = @(C) derivative_function_opt(C,Nmat,Rmat,normalizing_image,mask);
-
 %[xc,histout,costdata,itc] = cgtrust(lc01_norm(:),func,[10,0.1,60,20],1e-8);
 
 %[x,histout,costdata] = steep(lambda(:),func,0,50);
@@ -53,7 +53,7 @@ xc_theta = convnsep({val,val,val,val},xcimage,'same');
 xc_theta1 = xc_theta./normalizing_image;
 
 xc_theta1(~mask) = 0;
-figure(66),imagesc(xc_theta1(:,:,45,13));
+figure(66),imagesc(xc_theta1(:,:,45,5));
 
 
 % % % options = optimset('Gradobj','on','Algorithm','trust-region-reflective','Hessian','off','Display','iter','MaxIter',5,'MaxFunEvals',1,...

--- a/reshape_image_To_original_dimensions.m
+++ b/reshape_image_To_original_dimensions.m
@@ -1,0 +1,16 @@
+function reshaped_image = reshape_image_To_original_dimensions(urimage,k,sz)
+
+n=length(sz);
+indx2=nan(1,n);
+%dimensions other k-th dimension, along which convolution will happen:
+otherdims = 1:n; otherdims(k)=[];
+
+% permute order: place k-th dimension as 1st, followed by all others:
+indx1=[k otherdims];
+
+% inverse permute order:
+indx2(indx1)=1:n;
+
+J = reshape(urimage,sz(indx1));
+%5. undo the permutation of step 1.
+reshaped_image = permute(J,indx2);

--- a/simulation_lesiondata.m
+++ b/simulation_lesiondata.m
@@ -1,5 +1,3 @@
-% simulation code - new (using brain mask)
-
 load('MNI152_T1_2mm_brain_mask.mat');
 load('weights.mat');
 
@@ -38,7 +36,7 @@ theta_in = imdilate(theta_in,strel('square',2));
 % % mask4(45:55,:,:,:) = 1;
 % % mask4(:,55:65,:,:) = 1;
 % % theta_in(mask4>0) = 0.05;
-kernel1D = fspecial('gaussian',[1,9],5);
+kernel1D = fspecial('gaussian',[1,3],3);
 % kernel1D = kernel1D./5;
 theta_in = convnsep({kernel1D,kernel1D,kernel1D,kernel1D},theta_in,'same');
 
@@ -55,7 +53,7 @@ mu0=norminv(theta_in,0,1);
 mu0(isinf(mu0)) = 1;
 
 data_simulated = [];
-numbers= randsample(50:300,10);
+numbers= randsample(400:500,10);
 Rmat = zeros(size(mu0));
 for n=1:10 
     pim=zeros(size(mu0(:,:,:,n)));
@@ -82,15 +80,18 @@ xcimage = reshape((1+tanh(x))./2,size(Nmat)); % getting theta_cap
 
 % sp1 = spmak(1:6:37,[1 1 1]);
 % val = fnval(sp1,1:37);
-sp1 = spmak(1:2:15,[1 1 1]);
-val = fnval(sp1,1:15);
+sp1 = spmak(1:2:11,[1 1 1]);
+val = fnval(sp1,1:11);
+sp11 = spmak(1:1:7,[1 1 1]);
+val1 = fnval(sp11,1:7);
 % sp1 = spmak(1:4:23,[1 1 1]);
 % val = fnval(sp1,1:23);
 val = val./(sum(val));
+val1 = val1./(sum(val1));
 
-normalizing_image = convnsep({val,val,val,val},ones(size(Rmat)),'same');
+normalizing_image = convnsep({val,val,val,val1},ones(size(Rmat)),'same');
 
-xc_theta = convnsep({val,val,val,val},xcimage,'same');
+xc_theta = convnsep({val,val,val,val1},xcimage,'same');
 
 xc_theta1 = xc_theta./normalizing_image;
 
@@ -98,12 +99,15 @@ xc_theta1(~mask) = 0;
 
 figure(66),imagesc(xc_theta1(:,:,45,5));colorbar
 
-kernel1D = fspecial('gaussian',[1,15],7);
-kernel1D = kernel1D./5;
-ni = convnsep({kernel1D,kernel1D,kernel1D,kernel1D},ones(size(theta_in)),'same');
-mu1=convnsep({kernel1D,kernel1D,kernel1D,kernel1D},mu0,'same');
+kernel1D = fspecial('gaussian',[1,11],3);
+kernel1D = kernel1D./sum(kernel1D);
+
+kernel1Ds = fspecial('gaussian',[1,5],3);
+kernel1Ds = kernel1Ds./sum(kernel1Ds);
+ni = convnsep({kernel1D,kernel1D,kernel1D,kernel1Ds},ones(size(theta_in)),'same');
+mu1=convnsep({kernel1D,kernel1D,kernel1D,kernel1Ds},mu0,'same');
 mu1 = mu1./ni;
-var1=convnsep({kernel1D.^2,kernel1D.^2,kernel1D.^2,kernel1D.^2},ones(size(mu0)),'same');
+var1=convnsep({kernel1D.^2,kernel1D.^2,kernel1D.^2,kernel1Ds.^2},ones(size(mu0)),'same');
 var1 = var1./var1;
 z1=mu1./sqrt(var1);
 
@@ -117,3 +121,19 @@ figure(68),imagesc(theta1(:,:,45,5));colorbar
 
 s = error.^2;
 mse = sum(s(:))/(91*109*91*10)
+rmse_percent = sqrt(mse/mean(theta1(:)>0))
+
+
+ratio = Rmat./Nmat;
+xc_ratio = convnsep({val,val,val,val1},ratio,'same');
+
+xc_ratio = xc_ratio./normalizing_image;
+figure(69),imagesc(xc_ratio(:,:,45,5));colorbar
+
+error_rn = theta1 - xc_ratio;
+s_rn = error_rn.^2;
+mse_rn = sum(s_rn(:))/(91*109*91*10)
+rmse_percent_rn = sqrt(mse_rn/mean(theta1(:)>0))
+
+% save('experiment_rn_details250.mat','theta1','xc_theta1','error','error_rn','ratio','mse','mse_rn',...
+%     'rmse_percent','rmse_percent_rn');

--- a/spline_coefficients_fft_implementation.m
+++ b/spline_coefficients_fft_implementation.m
@@ -1,0 +1,42 @@
+length = 7;
+
+% smoothing spline and its x-shift
+sp = spmak(1:1:length,[1 1 1]);
+val = fnval(sp,1:length);
+val = val./sum(val);
+
+% a = rand(91,109,91,10);
+% a1 = convnsep({val,val,val,val},a,'same')./convnsep({val,val,val,val},ones(size(a)),'same');
+output = theta1;
+
+%  Creating M-matrix (spline coefficients)
+[row,col,stack,time] = size(output);
+
+flag = 0;
+for i = [1 2 3 4]
+    
+    
+    [output_ur,output_sz] = unravel_image(output,i);
+    S = zeros(1, size(output,i));
+    S(end-2:end) = val(1:3);
+    S(1:4) = val(4:end);
+%     S = val;
+    Yf = fft(output_ur);
+    Sf = fft(S');
+    Ck = Yf./repmat(Sf,[1,size(output_ur,2)]);
+    M = zeros(numel([0:1:size(output_ur,1)-1]),size(output_ur,1));
+    for k = 1:size(output_ur,1)
+        column = exp((-1i* 2*pi * (k-1) * [0:1:size(output_ur,1)-1])./size(output_ur,1));
+        M(:,k) = column';
+    end
+    M = M';
+    inv_term = M'*M;
+    coeff= (inv_term)\M'*Ck;
+    ind = ones(1,4);
+    ind(i) = 2;
+    coeff_matrix = reshape_image_To_original_dimensions(coeff,i,round(output_sz));%./ind));
+    output = real(coeff_matrix);
+    
+end
+
+aout = convnsep({val,val,val,val},output,'same')./convnsep({val,val,val,val},ones(size(output)),'same');

--- a/stoch_grad_descent.m
+++ b/stoch_grad_descent.m
@@ -33,7 +33,7 @@ maxiter = 20;
 dxmin = 10;
 
 % step size ( 0.33 causes instability, 0.2 quite accurate)
-alpha = 0.15;
+alpha = 0.33;
 
 % initialize gradient norm, optimization vector, iteration counter, perturbation
 gnorm = inf; x = x0; niter = 0; dx = inf;

--- a/unravel_image.m
+++ b/unravel_image.m
@@ -1,0 +1,21 @@
+function [urimage,sz] = unravel_image(J,k)
+
+sz=size(J);
+n=length(sz);
+
+%dimensions other k-th dimension, along which convolution will happen:
+otherdims = 1:n; otherdims(k)=[];
+
+% permute order: place k-th dimension as 1st, followed by all others:
+indx1=[k otherdims];
+
+%perform convolution along k-th dimension:
+%
+%1. permute dimensions to place k-th dimension as 1st
+J = permute(J,indx1);
+%2. create a 2D array (i.e. "stack" all other dimensions, other than
+%k-th:
+J = reshape(J,sz(k),prod(sz(otherdims)));
+
+urimage = J;
+


### PR DESCRIPTION
Simulation_lesiondata.m - patches to make the ground truth more realistic but the error is around 3% till 4000 subjects and then increases - need to check

True spline implementation using FFT works well with 7-length spline for any size image, 15-length spline - 2nd dimension not working, 7-length spline for MRI image 2-knot spacing not correct - need to fix

Maximizing function (knot spacing 1), stoch_grad_descent (alpha adjustment), derivative function opt (knot spacing 1), simulation lesion data (knot spacing 2 and 1 in temporal, gaussian kernel -  (1,11)3 and (1,7)3 in temporal)